### PR TITLE
Replace all the docs emojis with the relative HTML notation

### DIFF
--- a/mkdocs/conceptual/cheshire_cat/agent.md
+++ b/mkdocs/conceptual/cheshire_cat/agent.md
@@ -14,4 +14,4 @@ The list of available tools can be manually filtered with hooks to condition the
 !!! note "Developer documentation"
     [Agent hooks](../../technical/API_Documentation/mad_hatter/core_plugin/hooks/agent.md)
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/cheshire_cat/agent.md
+++ b/mkdocs/conceptual/cheshire_cat/agent.md
@@ -14,4 +14,4 @@ The list of available tools can be manually filtered with hooks to condition the
 !!! note "Developer documentation"
     [Agent hooks](../../technical/API_Documentation/mad_hatter/core_plugin/hooks/agent.md)
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/cheshire_cat/rabbit_hole.md
+++ b/mkdocs/conceptual/cheshire_cat/rabbit_hole.md
@@ -24,4 +24,4 @@ end
 G["&#129693;"] --> H["&#128024;Episodic Memory"] 
 ```
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/cheshire_cat/rabbit_hole.md
+++ b/mkdocs/conceptual/cheshire_cat/rabbit_hole.md
@@ -13,15 +13,15 @@ Currently supported file formats are: `.txt`, `.md`, `.pdf` or `.html` via web U
 ```mermaid
 
 flowchart LR
-A["📄Document"] --> B[read];
-subgraph rb ["🐰RabbitHole"]
-B[read] --> C["🪝"];
-C["🪝"] --> D[recursive split];
-D["🪝recursive split"] --> E["🪝"];
-E["🪝"] --> F["🪝summarization"];
-F["🪝summarization"] --> G["🪝"];
+A["&#128196;Document"] --> B[read];
+subgraph rb ["&#128048;RabbitHole"]
+B[read] --> C["&#129693;"];
+C["&#129693;"] --> D[recursive split];
+D["&#129693;recursive split"] --> E["&#129693;"];
+E["&#129693;"] --> F["&#129693;summarization"];
+F["&#129693;summarization"] --> G["&#129693;"];
 end
-G["🪝"] --> H["🐘Episodic Memory"] 
+G["&#129693;"] --> H["&#128024;Episodic Memory"] 
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/llm.md
+++ b/mkdocs/conceptual/llm.md
@@ -32,4 +32,4 @@ For instance, measuring the distance between two points can inform us about the 
 !!! note "Developer documentation"
     [Language Models hooks](../technical/API_Documentation/mad_hatter/core_plugin/hooks/models.md)
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../technical/plugins/plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../technical/plugins/plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/llm.md
+++ b/mkdocs/conceptual/llm.md
@@ -32,4 +32,4 @@ For instance, measuring the distance between two points can inform us about the 
 !!! note "Developer documentation"
     [Language Models hooks](../technical/API_Documentation/mad_hatter/core_plugin/hooks/models.md)
 
-Nodes with the :hook: point the execution places where there is an available [hook](../technical/plugins/plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../technical/plugins/plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/memory/long_term_memory.md
+++ b/mkdocs/conceptual/memory/long_term_memory.md
@@ -25,7 +25,7 @@ flowchart LR
     end
     A[Query] --> LTM; 
     LTM --> E["&#129693;"];
-    E["&#129693;"] --> wm["&#9881;&#65039;&#128024;Working Memory"];
+    E["&#129693;"] --> wm["&#9881;&#128024;Working Memory"];
 ```
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/memory/long_term_memory.md
+++ b/mkdocs/conceptual/memory/long_term_memory.md
@@ -18,14 +18,14 @@ By default, the Cat queries the LTM to retrieve the relevant context that is use
 
 ```mermaid
 flowchart LR
-    subgraph LTM ["🐘Long Term Memory"]
+    subgraph LTM ["&#128024;Long Term Memory"]
             direction TB
             C[(Episodic)];
             D[(Declarative)];
     end
     A[Query] --> LTM; 
-    LTM --> E["🪝"];
-    E["🪝"] --> wm["⚙️🐘Working Memory"];
+    LTM --> E["&#129693;"];
+    E["&#129693;"] --> wm["&#9881;&#65039;&#128024;Working Memory"];
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/memory/vector_memory.md
+++ b/mkdocs/conceptual/memory/vector_memory.md
@@ -19,19 +19,19 @@ By default, Vector Memory Collections are created when the Cat is installed or a
 
 ```mermaid
 flowchart LR
-    subgraph CAT ["🐱Cheshire Cat"]
+    subgraph CAT ["&#128049;Cheshire Cat"]
         direction LR
-        subgraph LTM ["🐘Long Term Memory"]
+        subgraph LTM ["&#128024;Long Term Memory"]
             direction TB
             C[(Episodic Memory)];
             D[(Declarative Memory)];
         end
-        A["First Memory"] --> H["🪝"];
-        H["🪝"] --> C[(Episodic)];
-        H["🪝"] --> D[(Declarative )];
+        A["First Memory"] --> H["&#129693;"];
+        H["&#129693;"] --> C[(Episodic)];
+        H["&#129693;"] --> D[(Declarative )];
     end
     E[First Installation] ----> CAT;
     F[Memory Swap] ----> LTM;
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/memory/vector_memory.md
+++ b/mkdocs/conceptual/memory/vector_memory.md
@@ -34,4 +34,4 @@ flowchart LR
     F[Memory Swap] ----> LTM;
 ```
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/memory/working_memory.md
+++ b/mkdocs/conceptual/memory/working_memory.md
@@ -13,17 +13,17 @@ Moreover, the Working Memory collects the relevant context that is fetched from 
 
 ```mermaid
 flowchart LR
-    subgraph WM ["⚙️🐘️Working Memory"]
+    subgraph WM ["&#9881;&#65039;&#128024;&#65039;Working Memory"]
             direction TB
             CH[Chat History]
             C[Episodic Memory];
             D[Declarative Memory];
     end
-    A["🐘Long Term Memory"] --> E["🪝"]; 
-    E["🪝"] --> WM;
+    A["&#128024;Long Term Memory"] --> E["&#129693;"]; 
+    E["&#129693;"] --> WM;
     CH --> main_prompt[Main Prompt];
     C --> main_prompt[Main Prompt];
     D --> main_prompt[Main Prompt];
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/memory/working_memory.md
+++ b/mkdocs/conceptual/memory/working_memory.md
@@ -13,7 +13,7 @@ Moreover, the Working Memory collects the relevant context that is fetched from 
 
 ```mermaid
 flowchart LR
-    subgraph WM ["&#9881;&#65039;&#128024;&#65039;Working Memory"]
+    subgraph WM ["&#9881;&#128024;Working Memory"]
             direction TB
             CH[Chat History]
             C[Episodic Memory];
@@ -26,4 +26,4 @@ flowchart LR
     D --> main_prompt[Main Prompt];
 ```
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/conceptual/prompts/hyde.md
+++ b/mkdocs/conceptual/prompts/hyde.md
@@ -39,19 +39,19 @@ Sentence:
 
 ```mermaid
 flowchart LR
-    subgraph cat ["🐱Cheshire Cat"]
+    subgraph cat ["&#128049;Cheshire Cat"]
     direction LR
-    hyde["🪝HyDE prompt"] --> llm[Language Model];
+    hyde["&#129693;HyDE prompt"] --> llm[Language Model];
     llm -->|generates|answer[Hypothetical Answer];
-    answer -->|similarity search|ltm["🐘Long Term Memory"];
+    answer -->|similarity search|ltm["&#128024;Long Term Memory"];
     ltm --> context[Relevant Context];
     context --->|inserted in|prompt[Main Prompt];
     end
-    A["👤User"] ---->|sends message|hyde;
+    A["&#128100;User"] ---->|sends message|hyde;
     A --> prompt
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
 
 ## References
 

--- a/mkdocs/conceptual/prompts/main_prompt.md
+++ b/mkdocs/conceptual/prompts/main_prompt.md
@@ -113,7 +113,7 @@ flowchart LR
     MP -..->|fed back to|CAT -...-> Answer
 ```
 
-Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
 
 ## References
 

--- a/mkdocs/conceptual/prompts/main_prompt.md
+++ b/mkdocs/conceptual/prompts/main_prompt.md
@@ -90,30 +90,30 @@ i.e. the collection of notes the Cat reads from and writes to its reasoning when
 flowchart LR
     subgraph MP ["Main Prompt"]
 %%        direction LR
-        Prefix["🪝Prefix"];
-        Instructions["🪝Instructions"];
-        Suffix["🪝Suffix"];    
+        Prefix["&#129693;Prefix"];
+        Instructions["&#129693;Instructions"];
+        Suffix["&#129693;Suffix"];    
     end
-    subgraph CAT ["🐱Cheshire Cat"]
+    subgraph CAT ["&#128049;Cheshire Cat"]
         HyDE
-        subgraph LTM ["🐘Long Term Memory"]
+        subgraph LTM ["&#128024;Long Term Memory"]
 %%        direction
         C[(Episodic)];
         D[(Declarative)];
     end
-    subgraph Agent ["🤖Agent"]
+    subgraph Agent ["&#129302;Agent"]
         A[Agent Scratchpad];
     end
     end
     
-    U["👤User"] -->|sends message|HyDE ---> LTM["🐘Long Term Memory"];
-    C --> E["🪝"] ----> Prefix;
-    D --> E["🪝"] --> Prefix;
+    U["&#128100;User"] -->|sends message|HyDE ---> LTM["&#128024;Long Term Memory"];
+    C --> E["&#129693;"] ----> Prefix;
+    D --> E["&#129693;"] --> Prefix;
     A --> Suffix;
     MP -..->|fed back to|CAT -...-> Answer
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
 
 ## References
 

--- a/mkdocs/conceptual/prompts/summarization.md
+++ b/mkdocs/conceptual/prompts/summarization.md
@@ -22,15 +22,15 @@ summarization_prompt = """Write a concise summary of the following:
 ```mermaid
 
 flowchart LR
-A["📄Document"] --> B[read];
-subgraph rb ["🐰RabbitHole"]
-B[read] --> C["🪝"];
-C["🪝"] --> D[recursive split];
-D["🪝recursive split"] --> E["🪝"];
-E["🪝"] --> F["🪝summarization"];
-F["🪝summarization"] --> G["🪝"];
+A["&#128196;Document"] --> B[read];
+subgraph rb ["&#128048;RabbitHole"]
+B[read] --> C["&#129693;"];
+C["&#129693;"] --> D[recursive split];
+D["&#129693;recursive split"] --> E["&#129693;"];
+E["&#129693;"] --> F["&#129693;summarization"];
+F["&#129693;summarization"] --> G["&#129693;"];
 end
-G["🪝"] --> H["🐘Episodic Memory"] 
+G["&#129693;"] --> H["&#128024;Episodic Memory"] 
 ```
 
-Nodes with the :hook: point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.
+Nodes with the &#129693;; point the execution places where there is an available [hook](../plugins.md) to customize the execution pipeline.

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -21,9 +21,9 @@ If you want to build your custom AI architecture, the Cat can help you!
 
 | Cheshire Cat Features                                           |                                                                 |
 |-----------------------------------------------------------------|-----------------------------------------------------------------|
-| :tools: Can use external tools                                  | :scroll: Can ingest documents (.txt, .pdf, .md)                 |
-| :earth_africa: Language model agnostic                          | :elephant: Long term memory                                     |
-| :rocket: Extendible via [plugins](technical/plugins/plugins.md) in Python | :whale2: 100% [dockerized](https://docs.docker.com/get-docker/) |
+| &#129520; Can use external tools                                  | &#128220; Can ingest documents (.txt, .pdf, .md)                 |
+| :earth_africa: Language model agnostic                          | &#128024; Long term memory                                     |
+| &#128640; Extendible via [plugins](technical/plugins/plugins.md) in Python | :whale2: 100% [dockerized](https://docs.docker.com/get-docker/) |
 
 ## Get started now!
 
@@ -34,7 +34,7 @@ If you want to build your custom AI architecture, the Cat can help you!
 
 | Get in touch with us!                                                                                   |                                                                                                                                |
 |---------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------|
-| [:fontawesome-brands-discord: Discord](https://discord.gg/bHX5sNFCYU){ .md-button .md-button--primary } | :point_left: **Join our Discord server and** :point_down: <br/> **don't forget to give the project a star! ⭐ Thanks again!🙏** |
+| [:fontawesome-brands-discord: Discord](https://discord.gg/bHX5sNFCYU){ .md-button .md-button--primary } | :point_left: **Join our Discord server and** :point_down: <br/> **don't forget to give the project a star! &#11088; Thanks again!&#128591;** |
 
 ![Wikipedia picture of the Cheshire Cat](assets/img/cheshire-cat-tree-shade.jpg)
 

--- a/mkdocs/technical/basics/admin-interface.md
+++ b/mkdocs/technical/basics/admin-interface.md
@@ -1,4 +1,4 @@
-# :yarn: The Admin Interface
+# &#129526; The Admin Interface
 
 Chat with the Cat and configure it visually at `localhost:1865/admin`.  
 Source code for the admin can be found [here](https://github.com/cheshire-cat-ai/admin-vue). 

--- a/mkdocs/technical/basics/cat-core.md
+++ b/mkdocs/technical/basics/cat-core.md
@@ -1,5 +1,5 @@
 
-# :anatomical_heart: The Cat Core
+# &#129728; The Cat Core
 
 The core functionalities of The Cheshire Cat resides in the `/core` folder. The core exposes all of its APIs via the address `localhost:1865/`.
 The program has several endpoints that can be accessed via this address. All of these endpoints are thoroughly documented and can be easily tested using Swagger (available at `localhost:1865/docs`) or ReDoc (available at `localhost:1865/redoc`).
@@ -8,11 +8,11 @@ Some of these endpoints include:
 
 | Endpoint           | Method      | Description                                                                         |
 |--------------------|:------------|:------------------------------------------------------------------------------------|
-| ___/___            | `GET`       | :handshake: Return the message `"We're all mad here, dear!"` if the cat is running. |
-| ___/ws/___         | `WEBSOCKET` | :speech_balloon: Start a chat with the cat using websockets.                        |
-| ___/rabbithole/___ | `POST`      | :rabbit: Send a file (`.txt`, `.md` or `.pdf`) to the cat.                          |
+| ___/___            | `GET`       | &#129309; Return the message `"We're all mad here, dear!"` if the cat is running. |
+| ___/ws/___         | `WEBSOCKET` | &#128172; Start a chat with the cat using websockets.                        |
+| ___/rabbithole/___ | `POST`      | &#128007; Send a file (`.txt`, `.md` or `.pdf`) to the cat.                          |
 
-## :yarn: The Admin Interface
+## &#129526; The Admin Interface
 
 The frontend interface of The Cheshire Cat can be accessed via `localhost:1865/admin`. This interface provides users with an easy-to-use chat that act as playground and can be used to interact with your application. The Cat core uses a static build of the admin, source code can be found [here](https://github.com/cheshire-cat-ai/admin-vue).
 

--- a/mkdocs/technical/basics/interacting.md
+++ b/mkdocs/technical/basics/interacting.md
@@ -1,6 +1,6 @@
 
 
-## :speech_balloon: Interacting with the Cat
+## &#128172; Interacting with the Cat
 
 Example of how to implement a simple chat system using the websocket endpoint at `localhost:1865/ws/`.
 !!! info "Request JSON schema"
@@ -99,7 +99,7 @@ Example of how to implement a simple chat system using the websocket endpoint at
         cat_chat();
         ```
 
-## :rabbit: Interacting with Rabbithole
+## &#128007; Interacting with Rabbithole
 
 Example of how to send a text file (`.md`,`.pdf.`,`.txt`) to the Cat using the Rabbit Hole at `localhost:1865/rabbithole/`.
 

--- a/mkdocs/technical/getting-started.md
+++ b/mkdocs/technical/getting-started.md
@@ -1,4 +1,4 @@
-# :rocket: Getting started
+# &#128640; Getting started
 
 ## Download
 

--- a/mkdocs/technical/how-the-cat-works.md
+++ b/mkdocs/technical/how-the-cat-works.md
@@ -6,39 +6,39 @@
 
 The Cheshire Cat is made of many pluggable components that make it fully customizable.
 
-:speech_balloon: `Chat`
+&#128172; `Chat`
 :   This is the Graphical User Interface (GUI) component that allows you to interact directly with the Cat.  
     From the GUI, you can also set the language model you want the Cat to run.
 
-:rabbit: `Rabbit Hole`
+&#128048; `Rabbit Hole`
 :   This component handles the ingestion of documents.  
     Files that are sent down the *Rabbit Hole* are split into chunks and saved in the Cat's *declarative memory* to be further retrieved in the conversation. <link to declarative memory>
 
-:brain: `Large Language Model (LLM)`
+&#x1F9E0; `Large Language Model (LLM)`
 :   This is one of the core components of the Cheshire Cat framework.  
     A LLM is a Deep Learning model that's been trained on a huge volume of text data and can perform many types of language tasks.
     The model takes a text string as input (e.g. the user's prompt) and provides a meaningful answer.  
     The answer consistency and adequacy is enriched with the context of previous conversations and documents uploaded in the Cat's memory.
 
-:dna: `Embedder`
+&#x1F9EC; `Embedder`
 :   The embedder is another Deep Learning model similar to the LLM. Differently, it doesn't perform language tasks.
     The model takes a text string as input and encodes it in a numerical representation.  
     This operation allows to represent textual data as vectors and perform geometrical operation on them.
     For instance, given an input, the embedder is used to retrieve similar sentences from the Cat's memory.
 
-:elephant: `Vector Memory`
+&#128024; `Vector Memory`
 :   As a result of the *Embedder* encoding, we get a set of vectors that are used to store the Cat's memory in a vector database.
     Memories store not only the vector representation of the input, but also the time instant and personalized metadata to facilitate and enhance the information retrieval.
     The Cat embeds two types of vector memories, namely the *episodic* and *declarative* memories.  
     The formers are the things the human said in the past; the latter the documents sent down the *Rabbit hole*.  
 
-:robot: `Agent`
+&#129302; `Agent`
 :   This is another core component of the Cheshire Cat framework.  
     The agent orchestrates the calls that are made to the LLM.  
     This component allows the Cat to decide which action to take according to the input the user provides.  
     Possible actions range from holding the conversation to executing complex tasks, chaining predefined or custom [tools](plugins/plugins.md#tools).
 
-:jigsaw: `Plugins`
+&#129513; `Plugins`
 :   These are functions to extend the Cat's capabilities.
     [Plugins](plugins/plugins.md) are a set of [tools](plugins/plugins.md#tools) and [hooks](plugins/plugins.md#hooks)
     that allow the Agent to achieve complex goals. This component let the Cat assists you with tailored needs.

--- a/mkdocs/technical/plugins/hooks.md
+++ b/mkdocs/technical/plugins/hooks.md
@@ -1,4 +1,4 @@
-# :hook: Hooks
+# &#129693; Hooks
 
 Hooks are python functions that are called directly from the Cat at runtime.  
 They allow you to change how the Cat does things by changing prompt, memory, endpoints and much more.
@@ -13,7 +13,7 @@ Both Hooks and Tools are python functions, but they have strong differences:
 
 ## Available Hooks
 
-Hooks will be listed and documented as soon as possible ( help needed! 😸 ).
+Hooks will be listed and documented as soon as possible ( help needed! &#128568; ).
 
 At the moment you can hack around by exploring the available hooks in `core/cat/mad_hatter/core_plugin/hooks/`.
 All the hooks you find in there define default Cat's behaviour and are ready to be overridden by your plugins.

--- a/mkdocs/technical/plugins/plugins.md
+++ b/mkdocs/technical/plugins/plugins.md
@@ -1,4 +1,4 @@
-# :electric_plug: How to write a plugin
+# &#128268; How to write a plugin
 
 To write a plugin just create a new folder in `core/cat/plugins/`, in this example will be "myplugin".
 
@@ -31,7 +31,7 @@ from cat.mad_hatter.decorators import tool, hook
 
 You are now ready to change the Cat's behavior using Hooks and Tools.
 
-## :toolbox: Tools
+## &#129520; Tools
 
 Tools are python functions that can be selected from the language model (LLM). Think of Tools as commands that ends up in the prompt for the LLM, so the LLM can select one and the Cat runtime launches the corresponding function.  
 Here is an example of Tool to let the Cat tell you what time it is:
@@ -46,7 +46,7 @@ def get_the_time(tool_input, cat):
 
 More examples on tools [here](tools.md).
 
-## :hook: Hooks
+## &#129693; Hooks
 
 Hooks are also python functions, but they pertain the Cat's runtime and not striclty the LLM. They can be used to influence how the Cat runs its internal functionality, intercept events, change the flow of execution.  
 

--- a/mkdocs/technical/plugins/tools.md
+++ b/mkdocs/technical/plugins/tools.md
@@ -1,4 +1,4 @@
-# :toolbox: Tools
+# &#129520; Tools
 
 A Tool is a python function that can be called directly from the language model.  
 By "called" we mean that the LLM has a description of the available Tools in the prompt, and (given the conversation context) it can generate as output something like:
@@ -10,7 +10,7 @@ By "called" we mean that the LLM has a description of the available Tools in the
 So your `search_ecommerce` Tool will be called and given the input string `"white sport shoes"`.
 The output of your Tool will go back to the LLM or directly to the user:
 
-> Observation: "Mike air Jordania shoes are available for 59.99€"
+> Observation: "Mike air Jordania shoes are available for 59.99&#8364;"
 
 You can use Tools to:
 
@@ -319,7 +319,7 @@ def convert_currency(tool_input, cat):
     # Ask the Cat to convert the currency name into its symbol
     symbol = cat.llm(f"You will be given a currency code, translate the input in the corresponding currency symbol. \
                     Examples: \
-                        euro -> € \
+                        euro -> &#8364; \
                         {currency} -> [answer here]")  # (2)
     # Remove new line if any
     symbol = symbol.strip("\n")
@@ -331,7 +331,7 @@ def convert_currency(tool_input, cat):
     # Convert EUR to currency
     result = converter.convert(float(eur), "EUR", currency)
 
-    return f"{eur}€ = {float(result):.2f}{symbol}"
+    return f"{eur}&#8364; = {float(result):.2f}{symbol}"
 
 ```
 
@@ -351,7 +351,7 @@ the quality of our tool code.
 > 
 > **Action Input**: 67-JPY
 > 
-> **Observation**: 67€ = 9846.99¥
+> **Observation**: 67&#8364; = 9846.99&#165;
 
 
 TODO:
@@ -368,4 +368,4 @@ TODO:
 
 ## References
 
-[^1]:Schick, T., Dwivedi-Yu, J., Dessì, R., Raileanu, R., Lomeli, M., Zettlemoyer, L., ... & Scialom, T. (2023). Toolformer: Language models can teach themselves to use tools. arXiv preprint arXiv:2302.04761.
+[^1]:Schick, T., Dwivedi-Yu, J., Dess&#236;, R., Raileanu, R., Lomeli, M., Zettlemoyer, L., ... & Scialom, T. (2023). Toolformer: Language models can teach themselves to use tools. arXiv preprint arXiv:2302.04761.

--- a/mkdocs/technical/plugins/tools.md
+++ b/mkdocs/technical/plugins/tools.md
@@ -10,7 +10,7 @@ By "called" we mean that the LLM has a description of the available Tools in the
 So your `search_ecommerce` Tool will be called and given the input string `"white sport shoes"`.
 The output of your Tool will go back to the LLM or directly to the user:
 
-> Observation: "Mike air Jordania shoes are available for 59.99&#8364;"
+> Observation: "Mike air Jordania shoes are available for 59.99€"
 
 You can use Tools to:
 
@@ -319,7 +319,7 @@ def convert_currency(tool_input, cat):
     # Ask the Cat to convert the currency name into its symbol
     symbol = cat.llm(f"You will be given a currency code, translate the input in the corresponding currency symbol. \
                     Examples: \
-                        euro -> &#8364; \
+                        euro -> € \
                         {currency} -> [answer here]")  # (2)
     # Remove new line if any
     symbol = symbol.strip("\n")
@@ -331,7 +331,7 @@ def convert_currency(tool_input, cat):
     # Convert EUR to currency
     result = converter.convert(float(eur), "EUR", currency)
 
-    return f"{eur}&#8364; = {float(result):.2f}{symbol}"
+    return f"{eur}€ = {float(result):.2f}{symbol}"
 
 ```
 
@@ -351,7 +351,7 @@ the quality of our tool code.
 > 
 > **Action Input**: 67-JPY
 > 
-> **Observation**: 67&#8364; = 9846.99&#165;
+> **Observation**: 67€ = 9846.99¥;
 
 
 TODO:
@@ -368,4 +368,4 @@ TODO:
 
 ## References
 
-[^1]:Schick, T., Dwivedi-Yu, J., Dess&#236;, R., Raileanu, R., Lomeli, M., Zettlemoyer, L., ... & Scialom, T. (2023). Toolformer: Language models can teach themselves to use tools. arXiv preprint arXiv:2302.04761.
+[^1]:Schick, T., Dwivedi-Yu, J., Dessì, R., Raileanu, R., Lomeli, M., Zettlemoyer, L., ... & Scialom, T. (2023). Toolformer: Language models can teach themselves to use tools. arXiv preprint arXiv:2302.04761.

--- a/mkdocs/technical/tutorials/installation.md
+++ b/mkdocs/technical/tutorials/installation.md
@@ -1,4 +1,4 @@
-# :factory_worker: Installation & Customization
+# &#129489;&#8205;&#127981; Installation & Customization
 
 <iframe width="854" height="480"  src="https://www.youtube.com/embed/Rvx19TZBCrw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/mkdocs/technical/tutorials/installation.md
+++ b/mkdocs/technical/tutorials/installation.md
@@ -1,4 +1,4 @@
-# &#129489;&#8205;&#127981; Installation & Customization
+# &#129489; Installation & Customization
 
 <iframe width="854" height="480"  src="https://www.youtube.com/embed/Rvx19TZBCrw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 

--- a/mkdocs/technical/tutorials/overview.md
+++ b/mkdocs/technical/tutorials/overview.md
@@ -1,4 +1,4 @@
-# :eyes: Overview
+# &#128064; Overview
 
 THIS VIDEO PROCEDURE
 


### PR DESCRIPTION
Add Mac compatibility by replacing all the emoji with the relative HTML entities.

Atthached to this PR there is also the code of the parser I used and a curated list of emoji with all they representations (HEX, HTML, shortcode, etc).

**Be carefull because it can also parse unwanted parts of the MD files so be sure to read the results after!**
[emojiparser_py.txt](https://github.com/cheshire-cat-ai/docs/files/11923705/emojiparser_py.txt)
[emojilist_json.txt](https://github.com/cheshire-cat-ai/docs/files/11923707/emojilist_json.txt)
