### PR TITLE
Admin Inteface section moved from cat-core

### DIFF
--- a/mkdocs/technical/basics/admin-interface.md
+++ b/mkdocs/technical/basics/admin-interface.md
@@ -1,4 +1,5 @@
 # &#129526; The Admin Interface
 
-Chat with the Cat and configure it visually at `localhost:1865/admin`.  
-Source code for the admin can be found [here](https://github.com/cheshire-cat-ai/admin-vue). 
+The frontend interface of The Cheshire Cat can be accessed via `localhost:1865/admin`. This interface provides users with an easy-to-use chat that act as playground and can be used to interact with your application. The Cat core uses a static build of the admin, source code can be found [here](https://github.com/cheshire-cat-ai/admin-vue).
+
+All the cat's settings are available under this GUI's `Settings` menu.

--- a/mkdocs/technical/basics/cat-core.md
+++ b/mkdocs/technical/basics/cat-core.md
@@ -11,20 +11,3 @@ Some of these endpoints include:
 | ___/___            | `GET`       | &#129309; Return the message `"We're all mad here, dear!"` if the cat is running. |
 | ___/ws/___         | `WEBSOCKET` | &#128172; Start a chat with the cat using websockets.                        |
 | ___/rabbithole/___ | `POST`      | &#128007; Send a file (`.txt`, `.md` or `.pdf`) to the cat.                          |
-
-## &#129526; The Admin Interface
-
-The frontend interface of The Cheshire Cat can be accessed via `localhost:1865/admin`. This interface provides users with an easy-to-use chat that act as playground and can be used to interact with your application. The Cat core uses a static build of the admin, source code can be found [here](https://github.com/cheshire-cat-ai/admin-vue).
-
-All the cat's settings are available under this GUI's `Settings` menu.
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
"Admin Interface" was written 2 times, in `cat-core.md` and in `admin-interface.md`.

- I put the text about the Admin Interface present in `cat-core.md` into `admin-interface.md`.
- I chose the section in `cat-core.md` over the one in `admin-interface.md` because it was more complete.