### PR TITLE
cat.llm.predict() no longer works

### DIFF
--- a/mkdocs/technical/plugins/tools.md
+++ b/mkdocs/technical/plugins/tools.md
@@ -317,7 +317,7 @@ def convert_currency(tool_input, cat):
         return "Something went wrong using the tool"
 
     # Ask the Cat to convert the currency name into its symbol
-    symbol = cat.llm.predict(f"You will be given a currency code, translate the input in the corresponding currency symbol. \
+    symbol = cat.llm(f"You will be given a currency code, translate the input in the corresponding currency symbol. \
                     Examples: \
                         euro -> € \
                         {currency} -> [answer here]")  # (2)


### PR DESCRIPTION
With [this commit](https://github.com/cheshire-cat-ai/core/commit/7a364bbf3230368f2d9807f44997408de5e10c00)  `cat.llm.predict()` no longer works. 
`cat.llm()` is the easiest way to do the same thing.