### PR TITLE
Removing http_reference from docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,6 @@ nav:
       - API:
           - API Endpoints: technical/basics/cat-core.md
           - API Authentication: technical/advanced/api_auth.md
-          - API Reference: technical/http_reference.md
       - Plugins Reference:
           - Plugin: technical/plugins/plugins.md
           - Tools: technical/plugins/tools.md

--- a/mkdocs/technical/http_reference.md
+++ b/mkdocs/technical/http_reference.md
@@ -1,6 +1,0 @@
-# API Reference
-
-Explore and try the endpoints easily by starting your Cat and opening the [`/docs`](http://localhost:1865/docs) endpoint.
-A static documentation of the endpoints is also available under [`/redoc`](http://localhost:1865/redoc)
-
-![Swagger endpoints screenshot](../assets/img/swagger_endpoints.png)


### PR DESCRIPTION
# Summary 
Removing http_reference.md from docs/mkdocs/technical and from the mkdocs.yml

# Impact
- https://cheshire-cat-ai.github.io/docs/technical/http_reference/ 
Will return 404 Not Found

#52 