### PR TITLE
Delete $ in the command section of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ We invite you to read the documentation for the [MkDocs Material theme](https://
 
 Install dependencies:  
 
-`$ pip install -r requirements.txt`
+`pip install -r requirements.txt`
 
 ### 🛠️ Develop
 
-`$ mkdocs serve` or `$ python -m mkdocs serve` will launch a local, non static, instance of the documentation website.
+`mkdocs serve` or `python -m mkdocs serve` will launch a local, non static, instance of the documentation website.
 
 ### 🖌️ Diagrams
 
@@ -42,4 +42,4 @@ Run action.
 
 The build stage is automated using GitHub action, you don't need to do it in order to contribute. However, if you want to have a static copy of the documentation on your local machine you are free to do it.  
 
-`$ mkdocs build` or `$ python -m mkdocs build` will create the actual docs static website in a folder named `/docs`. 
+`mkdocs build` or `python -m mkdocs build` will create the actual docs static website in a folder named `/docs`. 


### PR DESCRIPTION
I don't like the $ simbol to indicate that is a bash command. Also in pycharm, i can execute the command directly from the markdown file:
![Screenshot_20231206_171017](https://github.com/cheshire-cat-ai/docs/assets/26926690/3dd9cf3e-d036-4733-ac8a-1883a5ba6550)
