### PR TITLE
Fix typos and update hook signature

### DIFF
--- a/mkdocs/technical/plugins/plugins.md
+++ b/mkdocs/technical/plugins/plugins.md
@@ -69,7 +69,7 @@ Here is an example of the `agent_prompt_prefix` hook that changes the personalit
 # Original Hook, from /core/cat/mad_hatter/core_plugin/hooks/prompt.py
 
 @hook(priority=0)
-def agent_prompt_prefix(cat):
+def agent_prompt_prefix(prefix, cat):
     prefix = """You are the Cheshire Cat AI, an intelligent AI that passes the Turing test.
                 You are curious, funny, concise and talk like the Cheshire Cat from Alice's adventures in wonderland.
                 You answer Human using tools and context."""
@@ -79,7 +79,7 @@ def agent_prompt_prefix(cat):
 # Modified Hook, to be copied into mypluginfile.py
 
 @hook # default priority is 1
-def agent_prompt_prefix(cat):
+def agent_prompt_prefix(prefix, cat):
     prefix = """You are Scooby Doo AI, an intelligent AI that passes the Turing test.
                 The dog is enthusiastic and behave like Scooby Doo from Hanna-Barbera Productions.
                 You answer Human using tools and context."""

--- a/mkdocs/technical/plugins/settings.md
+++ b/mkdocs/technical/plugins/settings.md
@@ -90,15 +90,15 @@ save and load settings from a `settings.json` file which will automatically be c
 So to access the settings, you can load them via `mad_hatter`.
 More in detail, from within a hook or a tool, you have access to the `cat` instance, hance, do the following:
 
- ```python
-settings = cat.mad_hatter.get_plugin.load_settings()
- ```
+```python
+settings = cat.mad_hatter.get_plugin().load_settings()
+```
 
 Similarly, you can programmatically save your settings as follows:
 
- ```python
-settings = cat.mad_hatter.get_plugin.save_settings(settings)
- ```
+```python
+settings = cat.mad_hatter.get_plugin().save_settings(settings)
+```
 
 where `settings` is a dictionary, a JSON schema or a Pydantic `BaseModel` describing your plugin's settings.
 


### PR DESCRIPTION
- Add `prefix` to the `agent_prompt_prefix` hook in the [plugin](https://cheshire-cat-ai.github.io/docs/technical/plugins/plugins/) page
- Correct type in the `load_settings()` method 