### PR TITLE
fix: pydantic BasicModel schema deprecated

### DIFF
--- a/mkdocs/technical/plugins/settings.md
+++ b/mkdocs/technical/plugins/settings.md
@@ -61,7 +61,7 @@ class DemoSettings(BaseModel):
 # Give your settings schema to the Cat.
 @plugin
 def settings_schema():   
-    return DemoSettings.schema()
+    return DemoSettings.model_json_schema()
 
 ```
 

--- a/mkdocs/technical/plugins/settings.md
+++ b/mkdocs/technical/plugins/settings.md
@@ -58,10 +58,10 @@ class DemoSettings(BaseModel):
     optional_enum: NameSelect = NameSelect.b
 
 
-# Give your settings schema to the Cat.
+# Give your settings model to the Cat.
 @plugin
-def settings_schema():   
-    return DemoSettings.model_json_schema()
+def settings_model():
+    return DemoSettings
 
 ```
 


### PR DESCRIPTION
## BaseModel schema deprecated

updating `schema` to `model_json_schema` in the plugin settings `DemoSettings`.
