### PR TITLE
fix: references and plugin installation

### DIFF
--- a/mkdocs/administrators/architecture.md
+++ b/mkdocs/administrators/architecture.md
@@ -18,7 +18,7 @@ The local Cat core path `./core` is mounted to the image `cheshire_cat_core`, by
 As default the Admin Portal connect to the core using `localhost` and port `1678`, these values can be customized using [environment variables](env-variables.md#core_host). This port is the only one exposed by the `cheshire_cat_core` image.
 
 ## Logging
-All the log messages are printed on the standard output and log level can be configured with [`LOG_LEVEL`](env-variables.md#log_level) environment variables.
+All the log messages are printed on the standard output and log level can be configured with [`LOG_LEVEL`](env-variables.md#log_level) environment variables. You can check logging system documentation [here](../technical/plugins/logging.md).
 
 ## Configuration
 Some options of the Core can be customized using [environment variables](env-variables.md).

--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -1,15 +1,19 @@
 # &#128075; Hello, dear!
+```
+"Every adventure requires a first step".
+(Alice's Adventures in Wonderland - Lewis Carroll)
+```
 
-## What is this?
+## Features
 
 The Cheshire Cat is an open-source, hackable and production-ready framework that allows developing intelligent personal 
-AI assistants agents on top of [Large Language Models](conceptual/llm.md) (LLM).
+AI assistant agents on top of [Large Language Models](conceptual/llm.md) (LLM).
 
-| Cheshire Cat Features                      |                                                                   |
-|--------------------------------------------|-------------------------------------------------------------------|
-| &#129520; API first framework              | &#128220; Can ingest documents                                    |
-| &#127757; Language model agnostic          | &#128024; Local Long term memory                                  |
-| &#128640; Extendable via plugins in Python | 	&#128011; 100% [dockerized](https://docs.docker.com/get-docker/) |
+| Cheshire Cat Features                                                                  |                                                                                   |
+|----------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
+| &#129520; API first framework [Explore](technical/clientlib/clientlib-python.md)       | &#128220; Can ingest documents [Explore](quickstart/upload-document.md)           |
+| &#127757; Language model agnostic                                                      | &#128024; Local Long term memory [Explore](conceptual/memory/long_term_memory.md) |
+| &#128640; Extendable via plugins in Python [Explore](technical/plugins/plugins.md)     | 	&#128011; 100% [dockerized](https://docs.docker.com/get-docker/)                 |
 
 ## Quick links
 

--- a/mkdocs/plugins-registry/installing-plugin.md
+++ b/mkdocs/plugins-registry/installing-plugin.md
@@ -8,7 +8,7 @@ Installing plugins from our registry is a seamless process that enhances your Ch
 2. **Plugins Tab**: Click on the "Plugins" tab within the dashboard.
 3. **Search and Filter**: Use the search or filter options to locate your desired plugin.
 4. **Installation**: Once you've found the plugin, click the "Install" button.
-5. **Wait for Completion**: Allow the installation process to complete. Although our dashboard doesn't feature an automatic refresh mechanism, wait for a few seconds and manually refresh your browser page.
+5. **Wait for Completion**: The admin will show a loading spinner until the plugin installation is not completed.
 
 
 ![Admin plugin install from registry](../assets/img/admin_screenshots/install-plugin-from-registry.gif)
@@ -27,5 +27,5 @@ Manual installation grants users more control over the process and facilitates t
 
 After installing a plugin, consider these steps:
 
-- **Refresh**: Manually refresh the page in your browser after a few moments. This ensures any freshly installed plugins display accurately within the dashboard.
+- **Refresh**: The admin refreshes automatically after the installation but if for some reason the plugin does not show, refresh the page or check cat logs for any errors;
 - **Settings Configuration**: If the newly installed plugin requires setup or configuration, look for the cog icon associated with the plugin. Click on it to access and adjust the plugin's settings according to your preferences.


### PR DESCRIPTION
# Description

- fixed plugin installation instructions since now the cat does not need a manual refresh of the page, after installation
- added `logging system` reference on architecture page
- optional imp on `hello dear` page