### PR TITLE
Removed menu "Guides-How to update the Cat Core"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,7 +103,7 @@ nav:
         - Cat as Sidecar of your product: use-cases/side-car.md
         - Cat as Discord BOT: use-cases/discord-bot.md
     - Guides:
-      - How to update the Cat Core: guides/update-the-core.md
+#      - How to update the Cat Core: guides/update-the-core.md
       - How to backup the Long Term Memory: technical/advanced/memory_backup.md
 
   - FAQ: faq.md


### PR DESCRIPTION
The update-the-core.md file was removed on December but the menu was not removed. Now we remove the menu.