### PR TITLE
Fix typo in hook table

### DIFF
--- a/mkdocs/technical/plugins/hooks.md
+++ b/mkdocs/technical/plugins/hooks.md
@@ -275,9 +275,9 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
         
             ```python
             from cat.mad_hatter.decorators import hook
-    
+
             @hook  # default priority = 1
-            def before_cat_recalls_memories(cat):
+            def after_cat_recalls_memories(cat):
                 # do whatever here
             ```
 


### PR DESCRIPTION
Just fixing what you see in the screenshot
![Screenshot 2024-02-08 000816](https://github.com/cheshire-cat-ai/docs/assets/10786872/6d4c6b54-b4b3-4471-aab5-55800373a3c5)
