### PR TITLE
Working memory update

### DIFF
--- a/mkdocs/conceptual/memory/working_memory.md
+++ b/mkdocs/conceptual/memory/working_memory.md
@@ -33,6 +33,22 @@ The `working_memory` property returns an instance of the `WorkingMemory` class, 
 
 This flexibility allows you to access and set attributes using dot notation, creating and assigning arbitrary attributes on the fly. This makes the Working Memory highly adaptable for handling dynamic data structures.
 
+## Default Properties
+
+The Working Memory has some default properties used all around the framework that are initialized at different stages of the execution flow. 
+
+| Property               | Type                    | Description                                    | Initialization                                                           |
+|------------------------|-------------------------|------------------------------------------------|--------------------------------------------------------------------------|
+| `history`              | `List`                  | Stores the history of interactions.            | At the start of a conversation.                                          |
+| `user_message_json`    | `None` \| `UserMessage` | Holds the current user message in JSON format. | Whenever the Cat receives a message from a user.                         |
+| `active_form`          | `None` \| `CatForm`     | Tracks the active form being used.             | Upon a [form](../../technical/plugins/forms.md) instance initialization. |
+| `recall_query`         | `str`                   | Stores the query used for recalling memories.  | When the Agent recalls relevant memories.                                |
+| `episodic_memories`    | `List`                  | Contains recalled episodic memories.           | When the Agent recalls relevant memories.                                |
+| `declarative_memories` | `List`                  | Contains recalled declarative memories.        | When the Agent recalls relevant memories.                                |
+| `procedural_memories`  | `List`                  | Contains recalled procedural memories.         | When the Agent recalls relevant memories.                                |
+
+These properties are fundamental to the framework's functionality. However, they can be beneficial for various applications, such as performing specific checks on the chat history whenever a new message arrives or accessing the current message for additional processing. You can use them to suit your particular needs!
+
 ## Use the Working Memory as a State Machine
 
 One of the most powerful features of the Working Memory is its ability to function as a state machine.

--- a/mkdocs/technical/plugins/forms.md
+++ b/mkdocs/technical/plugins/forms.md
@@ -173,12 +173,12 @@ The method has two parameters:
 
 The method must return a dictionary where the value of the `output` key is a string that will be displayed in the chat.
 
-If you need to use the Form in future conversations, you can retrieve the model from the working memory by accessing the `form` key.
+If you need to use the Form in future conversations, you can retrieve the active form from the working memory by accessing the `active_form` key.
 
 Here is an example:
 
 ```python
     @hook  
     def before_cat_sends_message(message, cat):
-        form_data = cat.working_memory["form"]
+        active_form = cat.working_memory.active_form
 ```

--- a/mkdocs/technical/plugins/hooks.md
+++ b/mkdocs/technical/plugins/hooks.md
@@ -125,7 +125,7 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
             @hook  # default priority = 1 
             def before_cat_reads_message(user_message_json, cat):
                 user_message_json["text"] = "The original message has been replaced"
-                cat.working_memory["hacked"] = True
+                cat.working_memory.hacked = True
 
                 return user_message_json
             ```
@@ -372,7 +372,7 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
 
         ```python
         {
-            "input": working_memory["user_message_json"]["text"],  # user's message
+            "input": working_memory.user_message_json.text,  # user's message
             "episodic_memory": episodic_memory_formatted_content,  # strings with documents recalled from memories
             "declarative_memory": declarative_memory_formatted_content,
             "chat_history": conversation_history_formatted_content,
@@ -416,7 +416,7 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
                 # answer with predefined sentences if the Cat
                 # has no knowledge in the declarative memory
                 # (increasing the threshold memory is advisable)
-                if len(cat.working_memory["declarative_memories"]) == 0:
+                if len(cat.working_memory.declarative_memories) == 0:
                     fast_reply["output"] = "Sorry, I'm afraid I don't know the answer"
 
                 return fast_reply


### PR DESCRIPTION
Updated latest working memory page adding a table with default properties. This table has 4 columns: `Property`, `Type`, `Description`, `Initialization` (this last column to clarify when devs will find the specific property populated).

Updated also examples throughout the docs that were using old and deprecated access methods to the Working Memory which now works as a standard python object.

This should solve issue #163 