### PR TITLE
Small fix

### DIFF
--- a/mkdocs/index.md
+++ b/mkdocs/index.md
@@ -11,7 +11,7 @@ The Cheshire Cat is an open-source, hackable and production-ready framework that
 
 <div class="grid" markdown>
 
-[&#127939; Get started now](quickstart/installation-configuration.md){ .md-button .md-button-grid }
+[&#127939; Get started now](quickstart/introduction.md){ .md-button .md-button-grid }
  
 [&#129693; Available Hooks](plugins/hooks.md#available-hooks){ .md-button .md-button-grid }
 

--- a/mkdocs/plugins/hooks.md
+++ b/mkdocs/plugins/hooks.md
@@ -155,7 +155,7 @@ You should be able to run your own hooks also in tools and forms. Not fully test
 You can view the list of available hooks by exploring the Cat source code under the folder [`core/cat/mad_hatter/core_plugin/hooks`](https://github.com/cheshire-cat-ai/core/tree/main/core/cat/mad_hatter/core_plugin/hooks){:target="_blank"}.
 All the hooks you find in there define default Cat's behavior and are ready to be overridden by your plugins.
 
-The process diagrams found under the menu `Framework → Technical Diagrams` illustrate where the hooks are called during the Cat's execution flow.
+The process diagrams found under the [`Framework → Technical Diagrams`](../framework/flows/cat-bootstrap.md) section illustrate where the hooks are called during the Cat's execution flow.
 Not all the hooks have been documented yet. ( [help needed! &#128568;](https://discord.com/channels/1092359754917089350/1092360068269359206){:target="_blank"} ).
 
 === "&#127754; Flow"
@@ -696,16 +696,16 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
 
     <div class="annotate" mardown>
 
-    | Name                                      | Description                                                    |
-    | :---------------------------------------- | :------------------------------------------------------------- |
-    | Rabbit Hole instantiates parsers (1)      | Intervene before the files' parsers are instiated              |
-    | Before Rabbit Hole insert memory (2)      | Intervene before the Rabbit Hole insert a document in the declarative memory |
-    | Before Rabbit Hole splits text (3)        | Intervene before the uploaded document is split into chunks    |
-    | After Rabbit Hole splitted text (4)       | Intervene after the Rabbit Hole's split the document in chunks |
-    | Before Rabbit Hole stores documents (5)   | Intervene before the Rabbit Hole starts the ingestion pipeline |
-    | After Rabbit Hole stores documents (6)    | Intervene after the Rabbit Hole ended the ingestion pipeline   |
-    | Rabbit Hole instantiates parsers (7)      | Hook the available parsers for ingesting files in the declarative memory   |
-    | Rabbit Hole instantiates splitter (8)     | Hook the splitter used to split text in chunks                 |
+    | Name                                    | Description                                                                  |
+    | :-------------------------------------- | :--------------------------------------------------------------------------- |
+    | Rabbit Hole instantiates parsers (1)    | Intervene before the files' parsers are instiated                            |
+    | Before Rabbit Hole insert memory (2)    | Intervene before the Rabbit Hole insert a document in the declarative memory |
+    | Before Rabbit Hole splits text (3)      | Intervene before the uploaded document is split into chunks                  |
+    | After Rabbit Hole splitted text (4)     | Intervene after the Rabbit Hole's split the document in chunks               |
+    | Before Rabbit Hole stores documents (5) | Intervene before the Rabbit Hole starts the ingestion pipeline               |
+    | After Rabbit Hole stores documents (6)  | Intervene after the Rabbit Hole ended the ingestion pipeline                 |
+    | Rabbit Hole instantiates parsers (7)    | Hook the available parsers for ingesting files in the declarative memory     |
+    | Rabbit Hole instantiates splitter (8)   | Hook the splitter used to split text in chunks                               |
 
     </div>
 
@@ -918,14 +918,14 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
 
     <div class="annotate" mardown>
 
-    | Name                | Description                                        |
-    | :-------------------| :------------------------------------------------- |
-    | Activated (1)       | Intervene when a plugin is enabled                 |
-    | Deactivated (2)     | Intervene when a plugin is disabled                |
-    | Settings schema (3) | Override how the plugin's settings are retrieved   |
-    | Settings model (4)  | Override how the plugin's settings are retrieved   |
-    | Load settings (5)   | Override how the plugin's settings are loaded      |
-    | Save settings (6)   | Override how the plugin's settings are saved       |
+    | Name                | Description                                      |
+    | :------------------ | :----------------------------------------------- |
+    | Activated (1)       | Intervene when a plugin is enabled               |
+    | Deactivated (2)     | Intervene when a plugin is disabled              |
+    | Settings schema (3) | Override how the plugin's settings are retrieved |
+    | Settings model (4)  | Override how the plugin's settings are retrieved |
+    | Load settings (5)   | Override how the plugin's settings are loaded    |
+    | Save settings (6)   | Override how the plugin's settings are saved     |
 
     </div>
 
@@ -1159,10 +1159,10 @@ Not all the hooks have been documented yet. ( [help needed! &#128568;](https://d
 
     <div class="annotate" mardown>
 
-    | Name                              | Description                                         |
-    | :---------------------------------| :---------------------------------------------------|
-    | Factory Allowed LLMs (1)          | Intervene before cat retrive llm settings           |
-    | Factory Allowed Embedders (2)     | Intervene before cat retrive embedder settings      |
+    | Name                          | Description                                    |
+    | :---------------------------- | :--------------------------------------------- |
+    | Factory Allowed LLMs (1)      | Intervene before cat retrive llm settings      |
+    | Factory Allowed Embedders (2) | Intervene before cat retrive embedder settings |
     
     </div>
 

--- a/mkdocs/plugins/hooks.md
+++ b/mkdocs/plugins/hooks.md
@@ -152,7 +152,7 @@ You should be able to run your own hooks also in tools and forms. Not fully test
 
 ## Available Hooks
 
-You can view the list of available hooks by exploring the Cat source code under the folder `core/cat/mad_hatter/core_plugin/hooks`.
+You can view the list of available hooks by exploring the Cat source code under the folder [`core/cat/mad_hatter/core_plugin/hooks`](https://github.com/cheshire-cat-ai/core/tree/main/core/cat/mad_hatter/core_plugin/hooks){:target="_blank"}.
 All the hooks you find in there define default Cat's behavior and are ready to be overridden by your plugins.
 
 The process diagrams found under the menu `Framework → Technical Diagrams` illustrate where the hooks are called during the Cat's execution flow.

--- a/mkdocs/plugins/tools.md
+++ b/mkdocs/plugins/tools.md
@@ -99,7 +99,7 @@ You can simply use `@tool` or pass arguments.
     return "Tool output"
     ```
 
-## Tools debugging
+## Tools troubleshooting
 
 User's Input:
 > Can you tell me what time is it?

--- a/mkdocs/production/administrators/env-variables.md
+++ b/mkdocs/production/administrators/env-variables.md
@@ -57,11 +57,12 @@ Default value: `false`
 
 Enable this variable if you are using a proxy like Nginx with SSL in front of the Cat, otherwise https will give redirection problems.
 
+This option is mapped to the `--proxy_headers` Uvicorn option, you can reference the [Uvicorn HTTP setting](https://www.uvicorn.org/settings/#http){:target="_blank"} page for more info.
+
 ### CCAT_CORS_FORWARDED_ALLOW_IPS
 Default value: `*`
 
-TODO: explain this env 'cause I'm cooked
-
+When the `CCAT_HTTPS_PROXY_MODE` option is enabled, this option is mapped to the `--forwarded-allow-ips` Uvicorn option, you can reference the [Uvicorn HTTP setting](https://www.uvicorn.org/settings/#http){:target="_blank"} page for more info.
 
 ## Security
 

--- a/mkdocs/quickstart/installation-configuration.md
+++ b/mkdocs/quickstart/installation-configuration.md
@@ -9,7 +9,7 @@ Hence, when you run the Cat for the first time, you need to configure the LLM an
 Most people use [ChatGPT](https://platform.openai.com/docs/models/gpt-3-5), it's quite cheap and powerful enough.
 We will do the same during the next steps.
 
-To use `ChatGPT`, you need an API key. You can request one on the provider's website: 
+To use `ChatGPT`, you need an API key. You can request one on the provider's website:  
     - visit your OpenAI [API Keys](https://platform.openai.com/account/api-keys) page;  
     - create an API key with `+ Create new secret key` and copy it
 

--- a/mkdocs/quickstart/installation-configuration.md
+++ b/mkdocs/quickstart/installation-configuration.md
@@ -26,6 +26,7 @@ services:
     container_name: cheshire_cat_core
     ports:
       - 1865:80
+      - 5678:5678 # only for development purposes (take away in production)
     volumes:
       - ./static:/app/cat/static
       - ./plugins:/app/cat/plugins

--- a/mkdocs/quickstart/installing-plugin.md
+++ b/mkdocs/quickstart/installing-plugin.md
@@ -30,3 +30,6 @@ After installing a plugin, consider these steps:
 
 - **Refresh**: The admin refreshes automatically after the installation but if for some reason the plugin does not show, refresh the page or check cat logs for any errors;
 - **Settings Configuration**: If the newly installed plugin requires setup or configuration, look for the cog icon associated with the plugin. Click on it to access and adjust the plugin's settings according to your preferences.
+
+## Next Step
+In the [next step](./prepare-plugin.md), you will learn how easy it is to create your own plugin.

--- a/mkdocs/quickstart/installing-plugin.md
+++ b/mkdocs/quickstart/installing-plugin.md
@@ -1,6 +1,8 @@
 # &#128229; Installing a Plugin from the Registry
 
-Installing plugins from our registry is a seamless process that enhances your Cheshire Cat AI experience. Whether you're seeking specific functionalities or exploring new features, our registry offers a diverse range of plugins ready for installation.
+Plugins are a way to enhance Cheshire Cat AI. Developers from around the world create plugins and can choose to publish them in our public registry.
+
+Installing plugins from the registry is a seamless process that further enhances your Cheshire Cat AI experience. Whether you're seeking specific functionalities or exploring new features, our registry offers a diverse range of plugins ready for installation.
 
 ## Through the Admin Dashboard
 

--- a/mkdocs/quickstart/introduction.md
+++ b/mkdocs/quickstart/introduction.md
@@ -41,12 +41,11 @@ Other users will be able to install them with just a single click.
 
 ## Admin Portal
 A web portal for Admin users completes the framework.
-Using this portal, the admin can configure the settings,
-install plugins, upload documents and use it as a playground tool.
+Using this portal, the admin can configure the settings, install plugins, upload documents and use it as a playground tool.
 You can chat with the Cheshire Cat, inspect its responses and directly query its memories.
 
 ## Next step
-In the next step, you will learn how to install the Cat, set the LLM and the basics of this all.
+In the [next step](./installation-configuration.md), you will learn how to install the Cat, set the LLM and the basics of this all.
 
 We will be transforming the Cat into a sock seller.
 More in detail, we will upload some knowledge (documents) about socks knitting.

--- a/mkdocs/quickstart/introduction.md
+++ b/mkdocs/quickstart/introduction.md
@@ -37,7 +37,7 @@ The `Mad Hatter` is the component that manages plugins.
 
 ## Sharing Plugins
 If desired, you can publish your `Plugins` on the public registry.
-Other users will be able to install them with just a single click from the Admin Portal.
+Other users will be able to install them with just a single click.
 
 ## Admin Portal
 A web portal for Admin users completes the framework.

--- a/mkdocs/quickstart/play-with-the-cat.md
+++ b/mkdocs/quickstart/play-with-the-cat.md
@@ -80,7 +80,8 @@ Cheshire Cat: {
 This example explains the **Raw** use of the Cat APIs, however there are convinient and ready-made libraries available for various languages!
 #### More Info
 
+These are client libraries for different languages to speed up the connection with the Cat:
 [`Production -> Client Libraries`](../production/network/clients.md)
 
 ## Next Step
-In the [next step](./upload-document.md), you will learn how to load information into the cat by uploading documents.
+In the [next step](./upload-document.md), you will learn how to load information into the Cat by uploading documents.

--- a/mkdocs/quickstart/play-with-the-cat.md
+++ b/mkdocs/quickstart/play-with-the-cat.md
@@ -78,7 +78,9 @@ Cheshire Cat: {
 ```
 
 This example explains the **Raw** use of the Cat APIs, however there are convinient and ready-made libraries available for various languages!
-
 #### More Info
 
-[`Developers -> Client Libraries`](../production/network/clients.md)
+[`Production -> Client Libraries`](../production/network/clients.md)
+
+## Next Step
+In the [next step](./upload-document.md), you will learn how to load information into the cat by uploading documents.

--- a/mkdocs/quickstart/prepare-plugin.md
+++ b/mkdocs/quickstart/prepare-plugin.md
@@ -38,7 +38,7 @@ Your empty plugin will be there, activate it:
 
 #### More Info
 
-[Developers → Plugins Reference → Plugin](../plugins/plugins.md)
+[`Developers → Plugins Reference → Plugin`](../plugins/plugins.md)
 
 ## Next Step
 

--- a/mkdocs/quickstart/prepare-plugin.md
+++ b/mkdocs/quickstart/prepare-plugin.md
@@ -1,15 +1,13 @@
 # &#128268; Your first Plugin
 
 Plugins are packages of `Tools` and `Hooks`.
-You don't distribute a `Tool` or a `Hook` directly, you will distribute a Plugin containing them.
+You don't distribute a `Tool` or a `Hook` directly, you will distribute a Plugin containing them. Don't worry, we'll explore what tools and hooks are in details in the upcoming steps. For now, let's start by creating an empty plugin.
 
 ## Creating the Plugin
 
-In this step, we will prepare an empty plugin and in the next steps we will insert a `Tool` and a `Hook` inside it.
-
 To create a plugin just create a new folder in `core/cat/plugins/`, for our first plugin the folder name will be `poetic_sock_seller`.
 
-You need two files to your plugin folder:
+You need two files in your plugin folder:
 
     ├── core
     │   ├── cat

--- a/mkdocs/quickstart/prepare-plugin.md
+++ b/mkdocs/quickstart/prepare-plugin.md
@@ -40,6 +40,8 @@ Your empty plugin will be there, activate it:
 
 [`Developers → Plugins Reference → Plugin`](../plugins/plugins.md)
 
+[`Plugins -> Registry`](../plugins/plugins-registry/plugin-from-template.md)
+
 ## Next Step
 
 In the [next step](./writing-tool.md), you will learn how to create your first `Tool`.

--- a/mkdocs/quickstart/prepare-plugin.md
+++ b/mkdocs/quickstart/prepare-plugin.md
@@ -38,9 +38,9 @@ Your empty plugin will be there, activate it:
 
 #### More Info
 
-[`Developers → Plugins Reference → Plugin`](../plugins/plugins.md)
+Here the plugins reference: [`Plugins`](../plugins/plugins.md)
 
-[`Plugins -> Registry`](../plugins/plugins-registry/plugin-from-template.md)
+If you plan to publish your plugin, also take a look at this [`Plugins -> Registry`](../plugins/plugins-registry/plugin-from-template.md)
 
 ## Next Step
 

--- a/mkdocs/quickstart/stopping-the-cat.md
+++ b/mkdocs/quickstart/stopping-the-cat.md
@@ -10,3 +10,17 @@ docker compose down
 
 We want to remind you that Long-Term Memory is a locally persisted memory.
 When you restart the Cat, all conversation history and uploaded documents will still be there.
+
+## Next Step
+
+Congratulations on completing the quickstart!  
+
+We encourage you to explore the Cat further and try writing and publish your own plugins to enhance your experience.  
+
+If you have any questions or need assistance, feel free to join our [:fontawesome-brands-discord: Discord](https://discord.gg/bHX5sNFCYU) community to:
+
+- connect with other developers
+- ask for support to the contributors
+- see what people have already done with the Cat
+- join regular dev & user meetings
+- follow monthly live tutorials called Meow Talks

--- a/mkdocs/quickstart/stopping-the-cat.md
+++ b/mkdocs/quickstart/stopping-the-cat.md
@@ -15,7 +15,7 @@ When you restart the Cat, all conversation history and uploaded documents will s
 
 Congratulations on completing the quickstart!  
 
-We encourage you to explore the Cat further and try writing and publish your own plugins to enhance your experience.  
+We encourage you to explore the Cat further and try writing and publishing your own plugins to enhance your experience.  
 
 If you have any questions or need assistance, feel free to join our [:fontawesome-brands-discord: Discord](https://discord.gg/bHX5sNFCYU) community to:
 

--- a/mkdocs/quickstart/upload-document.md
+++ b/mkdocs/quickstart/upload-document.md
@@ -31,4 +31,4 @@ In this case, you can see that it used the knowledge coming from the documents (
 ![Alt text](../assets/img/quickstart/upload-document/why-response.png)
 
 ## Next Step
-In the [next step](./prepare-plugin.md), you will learn how to prepare an empty Plugin.
+In the [next step](./installing-plugin.md), you will learn what a plugin is and how to install it.

--- a/mkdocs/quickstart/writing-hook.md
+++ b/mkdocs/quickstart/writing-hook.md
@@ -57,7 +57,7 @@ The `agent_prompt_prefix` hook, in particular, allows instructing the Cat about 
 
 #### More Info
 
-[Developers → Plugins Reference → Hooks](../plugins/hooks.md)
+Hooks reference: [Plugins → Hooks](../plugins/hooks.md)
 
 ## Next Step
 

--- a/mkdocs/quickstart/writing-hook.md
+++ b/mkdocs/quickstart/writing-hook.md
@@ -59,6 +59,8 @@ The `agent_prompt_prefix` hook, in particular, allows instructing the Cat about 
 
 Hooks reference: [Plugins → Hooks](../plugins/hooks.md)
 
+The plugin management flow also is customizable (using the `plugin` decorator instead of `hook` ones). Check out [this](../plugins/hooks.md/#__tabbed_1_4) for more information
+
 ## Next Step
 
 In the [next step](./stopping-the-cat.md), you will learn how to `stop the cat`.

--- a/mkdocs/quickstart/writing-tool.md
+++ b/mkdocs/quickstart/writing-tool.md
@@ -93,14 +93,11 @@ The only limit is your fantasy &#128512;.
 When changes to the plugin's source code are detected, the Cat automatically restarts.
 Feel free to make changes within the code and observe the results.
 
-## Debugging
-
-Sometimes debugging can be necessary.
-Please refer to the `Developers -> Debugging` section for more information.
-
 #### More Info
 
-[Developers → Plugins Reference → Tools](../plugins/tools.md)
+Tools reference: [Plugins → Tools](../plugins/tools.md)
+
+Sometimes debugging can be necessary, please refer to the [`Plugins -> Debugging`](../plugins/debugging/vscode.md) section for more information.
 
 ## Next Step
 


### PR DESCRIPTION
- home page button "get started now" now is linked to the introduction page instead of installation page
- review and harmonised quickstart "next step" e "more info" sections
- added "next step" section to the last step of the quickstart
- review [CCAT_HTTPS_PROXY_MODE and CCAT_CORS_FORWARDED_ALLOW_IPS
- small others