### PR TITLE
fix: mermaid diagram

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,8 +187,8 @@ markdown_extensions:
       custom_checkbox: true
   - pymdownx.tabbed:
       alternate_style: true
-  #- pymdownx.superfences:
-  #    custom_fences:
-  #      - name: mermaid
-  #        class: mermaid
-  #        format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format


### PR DESCRIPTION
Fix: reactivating mermaid plugin so that mermaid diagrams are displayed correctly on docs

@nicola-corbellini @sambarza tagging both of you

I have noticed that the issue #190 is due to the commenting of mermaid plugin for mkdocs, I re-added it and tested it locally, the diagram is displayed correctly.
I have no idea if the mermaid plugin was commented for some important reasons or it was just an oversight that's why I want to check with you before merging.