### PR TITLE
Renamed Production->Administration, New Section "Make the Cat Private"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,12 +87,12 @@ nav:
         - Plugins Lifecycle: framework/flows/plugins-lifecycle.md
         - Rabbit Hole Ingestion: framework/flows/rabbit-hole-ingestion.md
 
-  - Production:
-    - Administration:
-        - Docker Compose: production/administrators/docker-compose.md
-        - Environment Variables: production/administrators/env-variables.md
-        - Automatic Tests: production/administrators/tests.md
-        - Backups and Updates: production/administrators/backups-updates.md
+  - Administration:
+    - Make the Cat Private: production/administrators/make_the_cat_private.md
+    - Docker Compose: production/administrators/docker-compose.md
+    - Environment Variables: production/administrators/env-variables.md
+    - Automatic Tests: production/administrators/tests.md
+    - Backups and Updates: production/administrators/backups-updates.md
     - Network:
       - WebSocket Endpoints: production/network/ws-endpoints.md
       - HTTP Endpoints: production/network/http-endpoints.md

--- a/mkdocs/production/administrators/make_the_cat_private.md
+++ b/mkdocs/production/administrators/make_the_cat_private.md
@@ -1,0 +1,14 @@
+The Cat installation is open by default, which means that all APIs are publicly accessible.  
+Below is a summary of the steps necessary to secure the installation.
+
+* Change the password for all the users using via Admin Portal
+
+* Secure the REST APIs and WebSocket by setting the following [environment](http://127.0.0.1:8000/docs/production/administrators/env-variables/) variables:
+```bash
+CCAT_API_KEY=a-very-long-and-alphanumeric-secret
+CCAT_API_KEY_WS=another-very-long-and-alphanumeric-secret
+```
+* Set a JWT hash secret to encrypt user data:
+```bash
+CCAT_JWT_SECRET=yet-another-very-long-and-alphanumeric-secret
+```


### PR DESCRIPTION
- Renamed then voice "Production" in then main menu bar to "Administration"
- Added new section, "Make the Cat private" under "Administration" menu

Next steps could be to reference the "Make the Cat private" section on:
- the "Settings" page of admin portal, so when the user change the password of the users should see 
- the "Login page"? to make clear that the Cat it's public by default