### PR TITLE
Title update to tools.md

### DIFF
--- a/mkdocs/plugins/tools.md
+++ b/mkdocs/plugins/tools.md
@@ -83,6 +83,7 @@ You can simply use `@tool` or pass arguments.
         examples : List[str] = []
     )
     ```
+### Tool arguments
 
 - Every `@tool` receives two arguments: a string representing the tool input, and a StrayCat instance.
     ```python


### PR DESCRIPTION
Adding the **Tool arguments** title in the tools documentation like it is in the hooks.md. I only did this because it's my first contribution but i think it would be nice make the tools doc and hooks doc more consistent to each other.